### PR TITLE
Update spotilib.py to support better artist, song separation

### DIFF
--- a/spotilib.py
+++ b/spotilib.py
@@ -25,7 +25,7 @@ def song_info():
 def artist():
 	try:
 		temp = song_info()
-		artist, song = temp.split("-",1)
+		artist, song = temp.split(" - ",1)
 		artist = artist.strip()
 		return artist
 	except:
@@ -34,7 +34,7 @@ def artist():
 def song():
 	try:
 		temp = song_info()
-		artist, song = temp.split("-",1)
+		artist, song = temp.split(" - ",1)
 		song = song.strip()
 		return song
 	except:


### PR DESCRIPTION
There's a few problems with the current split such that this happens:
`artist, song = "Blink-182 - I Miss You".split("-",1)`
`artist == "Blink"`
`song == "182 - I Miss You"`
This happens with other artists like T-Pain, Jay-Z, The B-52's, etc.
The Spotify window already puts it in the format of `Artist - Song` where there is a space on both sides of the hyphen