### PR TITLE
Fix get title for spotify uwp version

### DIFF
--- a/spotilib.py
+++ b/spotilib.py
@@ -1,7 +1,5 @@
 import win32gui
 import win32api
-import win32process
-import psutil
 import os
 
 ###Virtual-KeyCodes###
@@ -10,19 +8,27 @@ Media_Previous = 0xB1
 Media_Pause = 0xB3 ##Play/Pause
 Media_Mute = 0xAD
 
-def win_enum_handler(hwnd, names):
-    if win32gui.IsWindowVisible(hwnd):
-        pid = win32process.GetWindowThreadProcessId(hwnd)
-        process_name = psutil.Process(pid[1]).name()
-        music_name = win32gui.GetWindowText(hwnd)
-        if process_name == 'Spotify.exe' and len(music_name) != 0:
-            names.append(music_name)
+
+
+###SpotifyInfo###
+def getwindow(Title="SpotifyMainWindow"):
+	window_id = win32gui.FindWindow(Title, None)
+	return window_id
+
+###SpotifyInfoForUwpVersion###
+def getwindow_uwp(hwnd, hwnds):
+        song_info= win32gui.GetWindowText(hwnd)
+        if win32gui.GetClassName(hwnd) == "Chrome_WidgetWin_0" and len(song_info) > 0:
+        	hwnds.append(song_info)
+
 
 def song_info():
 	try:
-		name = []
-		win32gui.EnumWindows(win_enum_handler, name)
-		song_info = name[0]
+		song_info = win32gui.GetWindowText(getwindow())
+		if len(song_info) == 0:
+			hwnds = []
+			win32gui.EnumWindows(getwindow_uwp, hwnds)
+			song_info = hwnds[0]
 	except:
 		pass
 	return song_info

--- a/spotilib.py
+++ b/spotilib.py
@@ -1,5 +1,7 @@
 import win32gui
 import win32api
+import win32process
+import psutil
 import os
 
 ###Virtual-KeyCodes###
@@ -8,27 +10,19 @@ Media_Previous = 0xB1
 Media_Pause = 0xB3 ##Play/Pause
 Media_Mute = 0xAD
 
-
-
-###SpotifyInfo###
-def getwindow(Title="SpotifyMainWindow"):
-	window_id = win32gui.FindWindow(Title, None)
-	return window_id
-
-###SpotifyInfoForUwpVersion###
-def getwindow_uwp(hwnd, hwnds):
-        song_info= win32gui.GetWindowText(hwnd)
-        if win32gui.GetClassName(hwnd) == "Chrome_WidgetWin_0" and len(song_info) > 0:
-        	hwnds.append(song_info)
-
+def win_enum_handler(hwnd, names):
+    if win32gui.IsWindowVisible(hwnd):
+        pid = win32process.GetWindowThreadProcessId(hwnd)
+        process_name = psutil.Process(pid[1]).name()
+        music_name = win32gui.GetWindowText(hwnd)
+        if process_name == 'Spotify.exe' and len(music_name) != 0:
+            names.append(music_name)
 
 def song_info():
 	try:
-		song_info = win32gui.GetWindowText(getwindow())
-		if len(song_info) == 0:
-			hwnds = []
-			win32gui.EnumWindows(getwindow_uwp, hwnds)
-			song_info = hwnds[0]
+		name = []
+		win32gui.EnumWindows(win_enum_handler, name)
+		song_info = name[0]
 	except:
 		pass
 	return song_info

--- a/spotilib.py
+++ b/spotilib.py
@@ -25,6 +25,10 @@ def getwindow_uwp(hwnd, hwnds):
 def song_info():
 	try:
 		song_info = win32gui.GetWindowText(getwindow())
+		if len(song_info) == 0:
+			hwnds = []
+			win32gui.EnumWindows(getwindow_uwp, hwnds)
+			song_info = hwnds[0]
 	except:
 		pass
 	return song_info

--- a/spotilib.py
+++ b/spotilib.py
@@ -14,7 +14,14 @@ Media_Mute = 0xAD
 def getwindow(Title="SpotifyMainWindow"):
 	window_id = win32gui.FindWindow(Title, None)
 	return window_id
-	
+
+###SpotifyInfoForUwpVersion###
+def getwindow_uwp(hwnd, hwnds):
+        song_info= win32gui.GetWindowText(hwnd)
+        if win32gui.GetClassName(hwnd) == "Chrome_WidgetWin_0" and len(song_info) > 0:
+        	hwnds.append(song_info)
+
+
 def song_info():
 	try:
 		song_info = win32gui.GetWindowText(getwindow())


### PR DESCRIPTION
getwindow_uwp method added to spotilib.py.
In song_info mehtod an if block added to check if song_info length not 0 and if song length was 0 it uses getwindow_uwp method to get song_info .